### PR TITLE
Various cleanings and sortings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
-**/rust/target
+# Editors
 **/*.swp
+**/.vscode
+
+# Rust
+**/rust/target
+
+# Python
 **/__pycache__
-.vscode
+**/.pytest_cache

--- a/python/duplicate_encode/__init__.py
+++ b/python/duplicate_encode/__init__.py
@@ -1,0 +1,1 @@
+from .duplicate_encode import DuplicateEncode

--- a/python/duplicate_encode/__init__.py
+++ b/python/duplicate_encode/__init__.py
@@ -1,1 +1,1 @@
-from .duplicate_encode import DuplicateEncode
+from .duplicate_encode import *

--- a/python/duplicate_encode/duplicate_encode.py
+++ b/python/duplicate_encode/duplicate_encode.py
@@ -1,173 +1,91 @@
-def duplicate_encode_oneline_list(word):
-    """List comp version."""
-    return "".join(["(" if word.count(c) == 1 else ")" for c in word])  ##FIXME remove '[]' (and/or test)
+from collections import Counter, defaultdict
 
 
-def duplicate_encode_oneline_gen(word):
-    """List comp version."""
-    return "".join("(" if word.count(c) == 1 else ")" for c in word)
+class DuplicateEncode:
+    @staticmethod
+    def oneline_list(word):
+        """List comp version."""
+        return "".join(["(" if word.count(c) == 1 else ")" for c in word])
 
+    @staticmethod
+    def oneline_gen(word):
+        """List comp version."""
+        return "".join("(" if word.count(c) == 1 else ")" for c in word)
 
-from collections import Counter
-def duplicate_encode_oneline_vars(text):
-    """Combined version."""
-    counts = Counter(text)
-    return "".join([')' if counts[t]-1 else '(' for t in text])
+    @staticmethod
+    def oneline_vars(text):
+        """Combined version."""
+        counts = Counter(text)
+        return "".join([')' if counts[t] - 1 else '(' for t in text])
 
+    @staticmethod
+    def bash(word):
+        """Bash's version."""
+        counter = {}
 
-def duplicate_encode_bash(word):
-    """Bash's version."""
-    counter = {}
+        for char in word:
+            counter[char] = counter.get(char, 0) + 1
 
-    for char in word:
-        counter[char] = counter.get(char, 0) + 1
+        new_word = str()
+        for char in word:
+            new_word += '(' if counter[char] == 1 else ')'
 
-    new_word = str()
-    for char in word:  #FIXME   str comp here
-        new_word += '(' if counter[char] == 1 else ')'
+        return new_word
 
-    return new_word
+    @staticmethod
+    def bash_single_update(word):
+        """Bash's version - single update algorithm."""
+        counter = {}
 
+        for char in word:
+            if char not in counter:
+                counter[char] = 1
+            elif counter[char] == 1:
+                counter[char] = 2
 
-def duplicate_encode_bash_single_update(word):
-    """Bash's version - single update algorithm."""
-    counter = {}
+        new_word = str()
+        for char in word:
+            new_word += '(' if counter[char] == 1 else ')'
 
-    for char in word:
-        if char not in counter:
+        return new_word
+
+    @staticmethod
+    def bash_single_update_str_join_instead_of_concat(word):
+        """Bash's version - single update algorithm. using string.join instead of __radd__"""
+        counter = {}
+
+        for char in word:
+            if char not in counter:
+                counter[char] = 1
+            elif counter[char] == 1:
+                counter[char] = 2
+
+        return "".join(['(' if counter[char] == 1 else ')' for char in word])
+
+    @staticmethod
+    def bash_improved(text):
+        """Bash's "improved" version.
+
+        I tried using a dict comp here, but you can't reference yourself inside
+        of a comprehension, nor assign to an expression so the `a,b=a[b]={},5`
+        trick won't work. "Normal" dict it is...
+        """
+        counter = defaultdict(int)
+        for char in text:
+            counter[char] += 1
+
+        return "".join([')' if counter[char] - 1 else '(' for char in text])
+
+    @staticmethod
+    def bash_improved_single_update(text):
+        """Bash's "improved" (again) version."""
+        counter = defaultdict(int)
+        for char in text:
+            if char not in counter:
+                counter[char]
+                continue
+            if counter.get(char):
+                continue
             counter[char] = 1
-        elif counter[char] == 1:
-            counter[char] = 2
 
-    new_word = str()
-    for char in word:  #FIXME   str comp here
-        new_word += '(' if counter[char] == 1 else ')'
-
-    return new_word
-
-def duplicate_encode_bash_single_update_str_join_instead_of_concat(word):
-    """Bash's version - single update algorithm. using string.join instead of __radd__"""
-    counter = {}
-
-    for char in word:
-        if char not in counter:
-            counter[char] = 1
-        elif counter[char] == 1:
-            counter[char] = 2
-
-    return "".join(['(' if counter[char] == 1 else ')' for char in word])
-
-
-from collections import defaultdict
-def duplicate_encode_bash_improved(text):
-    """Bash's "improved" version.
-
-    I tried using a dict comp here, but you can't reference yourself inside
-    of a comprehension, nor assign to an expression so the `a,b=a[b]={},5`
-    trick won't work. "Normal" dict it is...
-    """
-    counter = defaultdict(int)
-    for char in text:
-        counter[char] += 1
-
-    return "".join([')' if counter[char]-1 else '(' for char in text])
-
-from collections import defaultdict
-def duplicate_encode_bash_improved_single_update(text):
-    """Bash's "improved" (again) version.
-
-    I tried using a dict comp here, but you can't reference yourself inside
-    of a comprehension, nor assign to an expression so the `a,b=a[b]={},5`
-    trick won't work. "Normal" dict it is...
-    """
-    counter = defaultdict(int)
-    for char in text:
-        if char not in counter:
-            counter[char]
-            continue
-        if counter.get(char):
-            continue
-        counter[char] = 1
-
-    return "".join([')' if counter[char] else '(' for char in text])
-
-
-
-number_of_test_runs=10
-input_word_size = 1_000_000
-# input_word_size = 1_000
-input_word_num = 10
-
-chars_per_test = number_of_test_runs * input_word_size * input_word_num
-skip_slow_algos = chars_per_test > 1_000_000
-
-print(f"counting {chars_per_test:,} characters per test (over {number_of_test_runs} tests for 5 functions")
-
-
-import random
-from datetime import datetime
-# seed randomizer with static value. if we run this more than once, then the
-# input will change.
-random.seed(42)
-start = datetime.now()
-print("making a random number...")
-input_word_chunk = "".join([random.choice([chr(x) for x in range(ord("0"), ord("z"))]) for _ in range(input_word_size)])
-input_word = input_word_chunk * input_word_num
-print(f"done makinga random number (took {datetime.now() - start})")
-
-
-from timeit import timeit
-from functools import partial
-oneliner_list  = partial(duplicate_encode_oneline_list,  input_word)
-oneliner_gen   = partial(duplicate_encode_oneline_gen,   input_word)
-debasheses     = partial(duplicate_encode_bash,          input_word)
-debasheses_su_join = partial(duplicate_encode_bash_single_update_str_join_instead_of_concat,          input_word)
-debasheses_su  = partial(duplicate_encode_bash_single_update, input_word)
-debasheses_imp = partial(duplicate_encode_bash_improved, input_word)
-debasheses_imp_su = partial(duplicate_encode_bash_improved_single_update, input_word)
-oneliner_vars  = partial(duplicate_encode_oneline_vars,  input_word)
-
-oneline_list, oneline_gen = None, None
-if not skip_slow_algos:
-    oneline_list  = timeit(oneliner_list,  number=number_of_test_runs)
-    oneline_gen   = timeit(oneliner_gen,   number=number_of_test_runs)
-debashis      = timeit(debasheses,     number=number_of_test_runs)
-debashis_su_join = timeit(debasheses_su_join,     number=number_of_test_runs)
-debashis_su   = timeit(debasheses_su,  number=number_of_test_runs)
-debashis_imp  = timeit(debasheses_imp, number=number_of_test_runs)
-debashis_imp_su  = timeit(debasheses_imp_su, number=number_of_test_runs)
-oneline_vars  = timeit(oneliner_vars,  number=number_of_test_runs)
-
-print("output sorted by speed on tener's computer")
-if not skip_slow_algos:
-    print(f"One-liner list:    {oneline_list} seconds")
-    print(f"One-liner gen:     {oneline_gen} seconds")
-else:
-    factor = chars_per_test / 10_000
-    # print(f"One-liner list:    skipped.............estimate: {6*factor/3600} hours")  these estimates are for an old version on a specific computer.. not good.
-    # print(f"One-liner gen:     skipped.............estimate: {9*factor/3600} hours")
-    print(f"One-liner list:    skipped; test is too big")
-    print(f"One-liner gen:     skipped; test is too big")
-print(f"Debashis:                        {debashis} seconds")
-print(f"Debashis single update:          {debashis_su} seconds")
-print(f"Debashis single update join:     {debashis_su_join} seconds")
-print(f"Debashis improved:               {debashis_imp} seconds")
-print(f"Debashis improved single update: {debashis_imp_su} seconds")
-print(f"One-liner vars:                  {oneline_vars} seconds")
-
-# correctness
-control_output, generator_output = None, None
-if not skip_slow_algos:
-    control_output       = duplicate_encode_oneline_list(input_word)
-    generator_output     = duplicate_encode_oneline_gen(input_word)
-debashis_output      = duplicate_encode_bash(input_word)
-debashis_output_su_join = duplicate_encode_bash_single_update_str_join_instead_of_concat(input_word)
-debashis_su_output   = duplicate_encode_bash_single_update(input_word)
-debashis_imp_output  = duplicate_encode_bash_improved(input_word)
-debashis_imp_su_output  = duplicate_encode_bash_improved_single_update(input_word)
-vars_output          = duplicate_encode_oneline_vars(input_word)
-
-if skip_slow_algos:
-    assert debashis_output == debashis_imp_output == vars_output == debashis_su_output == debashis_imp_su_output == debashis_output_su_join
-else:
-    assert control_output == generator_output == debashis_output == debashis_imp_output == vars_output == debashis_su_output == debashis_imp_su_output == debashis_output_su_join
+        return "".join([')' if counter[char] else '(' for char in text])

--- a/python/duplicate_encode/duplicate_encode.py
+++ b/python/duplicate_encode/duplicate_encode.py
@@ -1,109 +1,107 @@
 from collections import Counter, defaultdict
 
 
-class DuplicateEncode:
-    @staticmethod
-    def oneline_list(word):
-        """List comp version."""
-        return "".join(["(" if word.count(c) == 1 else ")" for c in word])
+def oneline_list(word):
+    """List comp version."""
+    return "".join(["(" if word.count(c) == 1 else ")" for c in word])
 
-    @staticmethod
-    def oneline_gen(word):
-        """List comp version."""
-        return "".join("(" if word.count(c) == 1 else ")" for c in word)
 
-    @staticmethod
-    def oneline_vars(text):
-        """Combined version."""
-        counts = Counter(text)
-        return "".join([')' if counts[t] - 1 else '(' for t in text])
+def oneline_gen(word):
+    """List comp version."""
+    return "".join("(" if word.count(c) == 1 else ")" for c in word)
 
-    @staticmethod
-    def bash(word):
-        """Bash's version."""
-        counter = {}
 
-        for char in word:
-            counter[char] = counter.get(char, 0) + 1
+def oneline_vars(text):
+    """Combined version."""
+    counts = Counter(text)
+    return "".join([')' if counts[t] - 1 else '(' for t in text])
 
-        new_word = str()
-        for char in word:
-            new_word += '(' if counter[char] == 1 else ')'
 
-        return new_word
+def bash(word):
+    """Bash's version."""
+    counter = {}
 
-    @staticmethod
-    def bash_single_update(word):
-        """Bash's version - single update algorithm."""
-        counter = {}
+    for char in word:
+        counter[char] = counter.get(char, 0) + 1
 
-        for char in word:
-            if char not in counter:
-                counter[char] = 1
-            elif counter[char] == 1:
-                counter[char] = 2
+    new_word = str()
+    for char in word:
+        new_word += '(' if counter[char] == 1 else ')'
 
-        new_word = str()
-        for char in word:
-            new_word += '(' if counter[char] == 1 else ')'
+    return new_word
 
-        return new_word
 
-    @staticmethod
-    def bash_single_update_str_join_instead_of_concat(word):
-        """Bash's version - single update algorithm. using string.join instead
-        of __radd__.
-        """
-        counter = {}
+def bash_single_update(word):
+    """Bash's version - single update algorithm."""
+    counter = {}
 
-        for char in word:
-            if char not in counter:
-                counter[char] = 1
-            elif counter[char] == 1:
-                counter[char] = 2
-
-        return "".join(['(' if counter[char] == 1 else ')' for char in word])
-
-    @staticmethod
-    def bash_single_lookup_and_update_str_join_instead_of_concat(word):
-        """Bash's version - single lookup and update algorithm. using
-        string.join instead of __radd__.
-        """
-        counter = {}
-
-        for char in word:
-            match counter.get(char):
-                case None:
-                    counter[char] = 1
-                case 1:
-                    counter[char] = 2
-
-        return "".join(['(' if counter[char] == 1 else ')' for char in word])
-
-    @staticmethod
-    def bash_improved(text):
-        """Bash's "improved" version.
-
-        I tried using a dict comp here, but you can't reference yourself inside
-        of a comprehension, nor assign to an expression so the `a,b=a[b]={},5`
-        trick won't work. "Normal" dict it is...
-        """
-        counter = defaultdict(int)
-        for char in text:
-            counter[char] += 1
-
-        return "".join([')' if counter[char] - 1 else '(' for char in text])
-
-    @staticmethod
-    def bash_improved_single_update(text):
-        """Bash's "improved" (again) version."""
-        counter = defaultdict(int)
-        for char in text:
-            if char not in counter:
-                counter[char]
-                continue
-            if counter.get(char):
-                continue
+    for char in word:
+        if char not in counter:
             counter[char] = 1
+        elif counter[char] == 1:
+            counter[char] = 2
 
-        return "".join([')' if counter[char] else '(' for char in text])
+    new_word = str()
+    for char in word:
+        new_word += '(' if counter[char] == 1 else ')'
+
+    return new_word
+
+
+def bash_single_update_str_join_instead_of_concat(word):
+    """Bash's version - single update algorithm. using string.join instead
+    of __radd__.
+    """
+    counter = {}
+
+    for char in word:
+        if char not in counter:
+            counter[char] = 1
+        elif counter[char] == 1:
+            counter[char] = 2
+
+    return "".join(['(' if counter[char] == 1 else ')' for char in word])
+
+
+def bash_single_lookup_and_update_str_join_instead_of_concat(word):
+    """Bash's version - single lookup and update algorithm. using
+    string.join instead of __radd__.
+    """
+    counter = {}
+
+    for char in word:
+        match counter.get(char):
+            case None:
+                counter[char] = 1
+            case 1:
+                counter[char] = 2
+
+    return "".join(['(' if counter[char] == 1 else ')' for char in word])
+
+
+def bash_improved(text):
+    """Bash's "improved" version.
+
+    I tried using a dict comp here, but you can't reference yourself inside
+    of a comprehension, nor assign to an expression so the `a,b=a[b]={},5`
+    trick won't work. "Normal" dict it is...
+    """
+    counter = defaultdict(int)
+    for char in text:
+        counter[char] += 1
+
+    return "".join([')' if counter[char] - 1 else '(' for char in text])
+
+
+def bash_improved_single_update(text):
+    """Bash's "improved" (again) version."""
+    counter = defaultdict(int)
+    for char in text:
+        if char not in counter:
+            counter[char]
+            continue
+        if counter.get(char):
+            continue
+        counter[char] = 1
+
+    return "".join([')' if counter[char] else '(' for char in text])

--- a/python/duplicate_encode/duplicate_encode.py
+++ b/python/duplicate_encode/duplicate_encode.py
@@ -51,7 +51,9 @@ class DuplicateEncode:
 
     @staticmethod
     def bash_single_update_str_join_instead_of_concat(word):
-        """Bash's version - single update algorithm. using string.join instead of __radd__"""
+        """Bash's version - single update algorithm. using string.join instead
+        of __radd__.
+        """
         counter = {}
 
         for char in word:
@@ -59,6 +61,22 @@ class DuplicateEncode:
                 counter[char] = 1
             elif counter[char] == 1:
                 counter[char] = 2
+
+        return "".join(['(' if counter[char] == 1 else ')' for char in word])
+
+    @staticmethod
+    def bash_single_lookup_and_update_str_join_instead_of_concat(word):
+        """Bash's version - single lookup and update algorithm. using
+        string.join instead of __radd__.
+        """
+        counter = {}
+
+        for char in word:
+            match counter.get(char):
+                case None:
+                    counter[char] = 1
+                case 1:
+                    counter[char] = 2
 
         return "".join(['(' if counter[char] == 1 else ')' for char in word])
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,2 @@
+pytest==6.2.5
+pytest-benchmark==3.4.1

--- a/python/tests/test_duplicate_encode.py
+++ b/python/tests/test_duplicate_encode.py
@@ -29,6 +29,7 @@ def input_text():
     DuplicateEncode.bash_improved,
     DuplicateEncode.bash_improved_single_update,
     DuplicateEncode.oneline_vars,
+    DuplicateEncode.bash_single_lookup_and_update_str_join_instead_of_concat,
 ])
 def test_funcs(func, input_text, benchmark):
     result = benchmark(func, input_text)

--- a/python/tests/test_duplicate_encode.py
+++ b/python/tests/test_duplicate_encode.py
@@ -31,7 +31,7 @@ def input_text():
     duplicate_encode.bash_improved,
     duplicate_encode.bash_improved_single_update,
 ])
-def test_funcs(func, input_text, benchmark):
+def test_benchmark_funcs_with_input_text(benchmark, func, input_text):
     result = benchmark(func, input_text)
 
     # Every character is always repeated because the input_text is chunked.

--- a/python/tests/test_duplicate_encode.py
+++ b/python/tests/test_duplicate_encode.py
@@ -4,7 +4,7 @@ from functools import partial
 
 import pytest
 
-from duplicate_encode import DuplicateEncode
+import duplicate_encode
 
 INPUT_TEXT_CHUNK_SIZE = 10_000
 NUM_INPUT_TEXT_CHUNKS = 10
@@ -21,15 +21,15 @@ def input_text():
 
 
 @pytest.mark.parametrize("func", [
-    DuplicateEncode.oneline_list,
-    DuplicateEncode.oneline_gen,
-    DuplicateEncode.bash,
-    DuplicateEncode.bash_single_update_str_join_instead_of_concat,
-    DuplicateEncode.bash_single_update,
-    DuplicateEncode.bash_improved,
-    DuplicateEncode.bash_improved_single_update,
-    DuplicateEncode.oneline_vars,
-    DuplicateEncode.bash_single_lookup_and_update_str_join_instead_of_concat,
+    duplicate_encode.oneline_list,
+    duplicate_encode.oneline_gen,
+    duplicate_encode.oneline_vars,
+    duplicate_encode.bash,
+    duplicate_encode.bash_single_update,
+    duplicate_encode.bash_single_update_str_join_instead_of_concat,
+    duplicate_encode.bash_single_lookup_and_update_str_join_instead_of_concat,
+    duplicate_encode.bash_improved,
+    duplicate_encode.bash_improved_single_update,
 ])
 def test_funcs(func, input_text, benchmark):
     result = benchmark(func, input_text)

--- a/python/tests/test_duplicate_encode.py
+++ b/python/tests/test_duplicate_encode.py
@@ -1,0 +1,41 @@
+import random
+from datetime import datetime
+from functools import partial
+
+import pytest
+
+from duplicate_encode import DuplicateEncode
+
+INPUT_TEXT_CHUNK_SIZE = 10_000
+NUM_INPUT_TEXT_CHUNKS = 10
+
+
+@pytest.fixture(scope='module')
+def input_text():
+    random.seed(42)
+    input_text_chunk = "".join(
+        [random.choice([chr(x) for x in range(ord("0"), ord("z"))]) for _ in range(INPUT_TEXT_CHUNK_SIZE)])
+    input_text = input_text_chunk * NUM_INPUT_TEXT_CHUNKS
+
+    yield input_text
+
+
+@pytest.mark.parametrize("func", [
+    DuplicateEncode.oneline_list,
+    DuplicateEncode.oneline_gen,
+    DuplicateEncode.bash,
+    DuplicateEncode.bash_single_update_str_join_instead_of_concat,
+    DuplicateEncode.bash_single_update,
+    DuplicateEncode.bash_improved,
+    DuplicateEncode.bash_improved_single_update,
+    DuplicateEncode.oneline_vars,
+])
+def test_funcs(func, input_text, benchmark):
+    result = benchmark(func, input_text)
+
+    # Every character is always repeated because the input_text is chunked.
+    assert result == ")" * (INPUT_TEXT_CHUNK_SIZE * NUM_INPUT_TEXT_CHUNKS)
+
+
+if __name__ == "__main__":
+    pytest.main()


### PR DESCRIPTION
This commit moves the testing to Pytest and benchmarking to a Pytest fixture plugin called `pytest-benchmark`.

It might be worth noting that now that this isn't a single file anymore, we get to deal with Python's horrible import system. To run the tests, you'll have to add the `<root>/python` directory to your PYTHONPATH environment variable, eg.:
```sh
# From the repo root
PYTHONPATH="./python" python python/tests/test_duplicate_encode.py
```

I've removed a bunch of the test generation code because `pytest-benchmark` takes care of it for us, but that also means that this isn't really an apples-to-apples comparison anymore with the rust version. We might consider making a file with our input chunk instead of generating it at runtime, then using that file in all languages/tests.